### PR TITLE
Create Github action for version tracking

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -1,0 +1,24 @@
+name: UpdateVersion
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  UpdateVersion:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version 5.0
+    - name: Update Version Number
+      run: dotnet fsi ./UpdateVersion.fsx
+    - run: git remote set-url origin ${{ secrets.ssh }}
+    - run: git status
+    - run: git add . 
+    - run: git commit -m "Auto updating version.txt"
+    - run: git fetch origin master
+    - name: pushing version.txt
+      run: git push origin HEAD:master

--- a/UpdateVersion.fsx
+++ b/UpdateVersion.fsx
@@ -1,0 +1,1 @@
+System.IO.File.WriteAllText(System.IO.Path.Combine(".","version.txt"),System.DateTime.UtcNow.Ticks.ToString()) // time since beginning of century

--- a/version.txt
+++ b/version.txt
@@ -1,0 +1,1 @@
+Will Be Filled in with time since beginning of century according to https://docs.microsoft.com/en-us/dotnet/api/system.datetime.ticks?view=net-5.0


### PR DESCRIPTION
On push/merge to master, version.txt gets updated with the time from century according to

https://docs.microsoft.com/en-us/dotnet/api/system.datetime.ticks?view=net-5.0

will be used by the launcher to maintain up to date modpack version.